### PR TITLE
Tests erven nu allemaal over van de BugTrapTest klasse (behalve Versi…

### DIFF
--- a/src/model/BugTrapInitializer.java
+++ b/src/model/BugTrapInitializer.java
@@ -173,7 +173,7 @@ class BugTrapInitializer {
 		}
 
 
-		bugTrap.getBugReportManager().addBugReport(title, descr, creation, sub, issuer, new ArrayList<>(), assigned, tag, 6);
+		bugTrap.getBugReportManager().addBugReport(title, descr, creation, sub, issuer, new ArrayList<>(), assigned, tag, null, 6);
 	}
 	
 	// -- XML Helpers --

--- a/src/model/bugreports/BugReport.java
+++ b/src/model/bugreports/BugReport.java
@@ -136,7 +136,13 @@ public class BugReport implements IBugReport {
 
 	@Override
 	public int compareTo(IBugReport otherBugReport) {
-		return getTitle().compareTo(otherBugReport.getTitle());
+		int c = getTitle().compareTo(otherBugReport.getTitle());
+		if (c < 0)
+			return -1;
+		else if (c > 0)
+			return 1;
+		else
+			return 0;
 	}
 
 	@Override

--- a/src/model/bugreports/BugReportManager.java
+++ b/src/model/bugreports/BugReportManager.java
@@ -1,5 +1,6 @@
 package model.bugreports;
 
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -75,35 +76,6 @@ public class BugReportManager {
 	}
 
 	/**
-<<<<<<< HEAD
-	 * returns all the bug reports for a given project
-	 * @param project Project to return BugReports for.
-	 * @return list of bug reports
-	 */
-	public List<IBugReport> getBugReportsForProject(IProject project) {
-		return getBugReportsForSystem(project);
-	}
-	
-	/**
-	 * Return all BugReports for given System.
-	 * @param system The System to get all BugReports for.
-	 * @return  The BugReports of given System.
-	 */
-	public List<IBugReport> getBugReportsForSystem(ISystem system) {
-		List<ISubsystem> subs = system.getAllDirectOrIndirectSubsystems();
-		List<IBugReport> reports = new ArrayList<IBugReport>();
-		if(system.getParent() != null)
-			subs.add((Subsystem) system);
-
-		for (IBugReport r : bugReportList)
-			for (ISubsystem s : subs)
-				if (r.getSubsystem() == s)
-					reports.add(r);
-
-		return reports;
-	}
-
-	/**
 	 * Delete the BugReports for given System and deletes the registrations for this bug report
 	 * @param system The System for which to delete the BugReports
 	 */
@@ -125,7 +97,11 @@ public class BugReportManager {
 	 * @param assignees Assignees of the BugReport
 	 * @param tag Tag of the BugReport
 	 */
-	public void addBugReport(String title, String description, Date creationDate, ISubsystem subsystem, IUser issuer, List<IBugReport> dependencies, List<IUser> assignees, BugTag tag, int impactFactor) {
+	public void addBugReport(String title, String description, Date creationDate, ISubsystem subsystem, IUser issuer, List<IBugReport> dependencies, List<IUser> assignees, BugTag tag, TargetMilestone milestone, int impactFactor) {
+		if (milestone != null) {
+			if(milestone.compareTo(subsystem.getAchievedMilestone()) <= 0) throw new IllegalArgumentException("The target milestone should be strict higher than the achieved milestone of the subsystem");
+		}
+
 		BugReport report = new BugReportBuilder(bugTrap).setTitle(title)
 				.setDescription(description)
 				.setSubsystem(subsystem)
@@ -135,35 +111,6 @@ public class BugReportManager {
 				.setAssignees(assignees)
 				.setBugTag(tag)
 				.setImpactFactor(impactFactor)
-				.getBugReport();
-		bugReportList.add(report);
-		((Subsystem)subsystem).signal(new BugReportCreationSignalisation(report));
-	}
-	
-	/**
-	 * Add a BugReport with a Target Milestone
-	 * @param title Title of the BugReport
-	 * @param description Description of the BugReport
-	 * @param creationDate Creation Date of the BugReport
-	 * @param subsystem Subsystem of the BugReport
-	 * @param issuer Issuer of the BugReport
-	 * @param dependencies Dependencies of the BugReport
-	 * @param assignees Assignees of the BugReport
-	 * @param tag Tag of the BugReport
-	 * @param milestone Target Milestone of the BugReport
-	 */
-	public void addBugReportWithTargetMilestone(String title, String description, Date creationDate, ISubsystem subsystem, IUser issuer, List<IBugReport> dependencies, List<IUser> assignees, BugTag tag, List<Integer> milestone) {
-		TargetMilestone target = new TargetMilestone(milestone);
-		if(target.compareTo(subsystem.getAchievedMilestone()) <= 0) throw new IllegalArgumentException("The target milestone should be strict higher than the achieved milestone of the subsystem");
-		
-		BugReport report = new BugReportBuilder(bugTrap).setTitle(title)
-				.setDescription(description)
-				.setSubsystem(subsystem)
-				.setIssuer(issuer)
-				.setDependsOn(dependencies)
-				.setCreationDate(creationDate)
-				.setAssignees(assignees)
-				.setBugTag(tag)
 				.setMilestone(milestone)
 				.getBugReport();
 		bugReportList.add(report);

--- a/src/model/bugreports/bugtag/New.java
+++ b/src/model/bugreports/bugtag/New.java
@@ -16,9 +16,6 @@ public class New extends BugTagState {
 
 	@Override
 	public BugTagState confirmBugTag(BugTagState bugTag) {
-		if (bugTag.isClosed())
-			throw new IllegalArgumentException();
-			
 		for (IBugReport dependency : bugReport.getDependsOn())
 			if (	dependency.getBugTag() != BugTag.CLOSED ||
 					dependency.getBugTag() != BugTag.RESOLVED)

--- a/src/model/bugreports/commands/CreateBugReportCommand.java
+++ b/src/model/bugreports/commands/CreateBugReportCommand.java
@@ -23,6 +23,6 @@ public class CreateBugReportCommand extends Command {
     @Override
     public void execute() throws UnauthorizedAccessException {
         form.allVarsFilledIn();
-        getBugTrap().getBugReportManager().addBugReport(form.getTitle(), form.getDescription(), new Date(), form.getSubsystem(), form.getIssuer(), form.getDependsOn(), new ArrayList<IUser>(), BugTag.NEW, form.getImpactFactor());
+        getBugTrap().getBugReportManager().addBugReport(form.getTitle(), form.getDescription(), new Date(), form.getSubsystem(), form.getIssuer(), form.getDependsOn(), new ArrayList<IUser>(), BugTag.NEW, form.getTargetMilestone(), form.getImpactFactor());
     }
 }

--- a/src/tests/BugTrapTest.java
+++ b/src/tests/BugTrapTest.java
@@ -46,6 +46,7 @@ public class BugTrapTest {
 
     protected IBugReport clippyBug;
     protected IBugReport wordBug;
+    protected IBugReport wordArtBug;
 
     @Before
     public void setUp() {
@@ -85,15 +86,18 @@ public class BugTrapTest {
         
         //Add BugReports.
         bugTrap.getUserManager().loginAs(lead);
-        bugTrap.getBugReportManager().addBugReport("Clippy bug!", "Clippy only pops up once an hour. Should be more.", new Date(1303), clippy, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, 5);
+        bugTrap.getBugReportManager().addBugReport("Clippy bug!", "Clippy only pops up once an hour. Should be more.", new Date(1303), clippy, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, null, 5);
         clippyBug = clippy.getAllBugReports().get(0);
         bugTrap.getBugReportManager().addComment(clippyBug, "Agreed! I propose once every 5 minutes!");
         ArrayList<IUser> assignees = new ArrayList<>();
         assignees.add(prog);
         ArrayList<IBugReport> dependencies = new ArrayList<>();
         dependencies.add(clippyBug);
-        bugTrap.getBugReportManager().addBugReport("Word crashes when Clippy pops up", "...", new Date(1305), word, lead, dependencies, assignees, BugTag.UNDERREVIEW, 7);
+        bugTrap.getBugReportManager().addBugReport("Word crashes", "As soon as Clippy pops up...", new Date(1305), word, lead, dependencies, assignees, BugTag.UNDERREVIEW, null, 7);
         wordBug = word.getAllBugReports().get(0);
+        dependencies = new ArrayList<>();
+        bugTrap.getBugReportManager().addBugReport("WordArt is not working", "When using Comic Sans, the Word Art does not work.", new Date(1310), wordArt, issuer, dependencies, assignees, BugTag.ASSIGNED, null, 3);
+        wordArtBug = wordArt.getAllBugReports().get(0);
 
         //Log off.
         bugTrap.getUserManager().logOff();

--- a/src/tests/CreateProjectUseCaseTest.java
+++ b/src/tests/CreateProjectUseCaseTest.java
@@ -1,9 +1,5 @@
 package tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -18,6 +14,8 @@ import model.projects.forms.DeclareAchievedMilestoneForm;
 import model.projects.forms.ProjectCreationForm;
 import model.projects.forms.ProjectForkForm;
 import model.users.IUser;
+
+import static org.junit.Assert.*;
 
 public class CreateProjectUseCaseTest extends BugTrapTest {
 
@@ -54,7 +52,6 @@ public class CreateProjectUseCaseTest extends BugTrapTest {
 		Date creationDate = new Date();
 		try {
 			projectController.createProject(form);
-			creationDate = new Date();
 			project = projectController.getProjectList().get(projectController.getProjectList().size() - 1);
 		} catch (UnauthorizedAccessException e) { fail("not authorised"); }
 
@@ -81,7 +78,7 @@ public class CreateProjectUseCaseTest extends BugTrapTest {
 		//-Has no parent system.
 		assertEquals(null,						project.getParent());
 		//-Has correct CreationDate.
-		assertEquals(creationDate,				project.getCreationDate());
+		assertTrue(Math.abs(project.getCreationDate().getTime() - new Date().getTime()) < 250);
 		//-Has one Achieved Milestone: M0
 		assertEquals("M0",						project.getAchievedMilestone().toString());
 	}

--- a/src/tests/DeclaredAchievedMilestoneUseCaseTest.java
+++ b/src/tests/DeclaredAchievedMilestoneUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 
 import java.util.*;
 
+import model.bugreports.TargetMilestone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -173,7 +174,7 @@ public class DeclaredAchievedMilestoneUseCaseTest extends BugTrapTest {
 		List<ISubsystem> ss = p.getAllDirectOrIndirectSubsystems();
 		ISubsystem sub = ss.get(0);
 		bugTrap.getProjectManager().declareAchievedMilestone(sub, Arrays.asList(new Integer[] {0,1}));
-		bugTrap.getBugReportManager().addBugReportWithTargetMilestone("title", "description", new Date(3), sub, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, Arrays.asList(new Integer[] {0,2}));
+		bugTrap.getBugReportManager().addBugReport("title", "description", new Date(3), sub, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, new TargetMilestone(Arrays.asList(new Integer[] {0,2})), 3);
 		
 		
 		//Step 1. The developer indicates that he wants to declare an achieved milestone.

--- a/src/tests/bugreporttests/BugReportFilterTest.java
+++ b/src/tests/bugreporttests/BugReportFilterTest.java
@@ -17,61 +17,58 @@ import model.bugreports.filters.FilterType;
 import model.users.Developer;
 import model.users.IUser;
 import model.users.Issuer;
+import tests.BugTrapTest;
 
-public class BugReportFilterTest {
+public class BugReportFilterTest extends BugTrapTest {
 
 	BugReportFilter bugReportFilter;
 	
 	@Before
-	public void setUp() throws Exception {
-		List<IBugReport> bugReports = new ArrayList<IBugReport>();
-		List<IUser> assignees1 = new ArrayList<IUser>();
-		List<IUser> assignees2 = new ArrayList<IUser>();
-		List<IUser> assignees3 = new ArrayList<IUser>();
-		
-		IUser developer1 = new Developer(null, null, null, "Louis");
-		IUser developer2 = new Developer(null, null, null, "Armstrong");
-		IUser developer3 = new Developer(null, null, null, "Duncan");
-		
-		assignees1.add(developer1); assignees1.add(developer2); assignees1.add(developer3);
-		assignees2.add(developer2); assignees2.add(developer3);
-		assignees3.add(developer1); assignees3.add(developer3);
-		
-		BugReport bugReport1 = new BugReport(null, "This is a BugReport", "Typo, low priority", null, null, assignees1, null, new Issuer(null, null, null, "George"), null, null, BugTag.NEW, null, null, null, null, null, null, 3);
-		BugReport bugReport2 = new BugReport(null, "Urgent!!!!", "Please take a look at this BugReport!", null, null, assignees2, null, new Issuer(null, null, null, "Michael"), null, null, BugTag.NEW, null, null, null, null, null, null, 5);
-		BugReport bugReport3 = new BugReport(null, "CRITICAL ERROR", "BEEP BOOP", null, null, assignees3, null, new Issuer(null, null, null, "George"), null, null, BugTag.NEW, null, null, null, null, null, null, 3);
-		
- 		bugReports.add(bugReport1); bugReports.add(bugReport2); bugReports.add(bugReport3);
-		
-		bugReportFilter = new BugReportFilter(bugReports);
-		
+	public void setUp() {
+		super.setUp();
+
+		// Add some additional bug reports
+
+		this.bugReportFilter = new BugReportFilter(this.bugReportController.getBugReportList());
 	}
 
 	@Test
 	public void byTitleOrDescrTest() {
-		String param = "BugReport";
+		String param = "Clippy";
 		List<IBugReport> result = bugReportFilter.filter(FilterType.CONTAINS_STRING, param);
 		
 		assertEquals(2, result.size());
 		
 		for (IBugReport bugReport : result)
 			assertTrue(bugReport.getTitle().contains(param) || bugReport.getDescription().contains(param));
+
+		param = "Word";
+		result = bugReportFilter.filter(FilterType.CONTAINS_STRING, param);
+		assertEquals(1, result.size());
+
+		param = "Somerandomwords";
+		result = bugReportFilter.filter(FilterType.CONTAINS_STRING, param);
+		assertEquals(0, result.size());
 	}
 	
 	@Test
 	public void filedByUserTest() {
-		String param = "George";
+		String param = lead.getUserName();
 		List<IBugReport> result = bugReportFilter.filter(FilterType.FILED_BY_USER, param);
 		
 		assertEquals(2, result.size());
 		
 		for (IBugReport bugReport : result) 
 			assertTrue(bugReport.getIssuedBy().getUserName().equals(param));
+
+		param = prog.getUserName();
+		result = bugReportFilter.filter(FilterType.FILED_BY_USER, param);
+		assertEquals(0, result.size());
 	}
 	
 	@Test
 	public void assignedToUserTest() {
-		String param = "Armstrong";
+		String param = prog.getUserName();
 		List<IBugReport> result = bugReportFilter.filter(FilterType.ASSIGNED_TO_USER, param);
 		
 		assertEquals(2, result.size());
@@ -81,9 +78,9 @@ public class BugReportFilterTest {
 		for (IBugReport bugReport : result) 
 			for (IUser user : bugReport.getAssignees())
 				if (user.getUserName().equals(param)) {
-					contains = true; break;
+					contains = true;
+					break;
 				}
 		assertTrue(contains);
 	}
-
 }

--- a/src/tests/bugreporttests/BugReportTest.java
+++ b/src/tests/bugreporttests/BugReportTest.java
@@ -29,8 +29,9 @@ import model.users.Administrator;
 import model.users.Developer;
 import model.users.IUser;
 import model.users.Issuer;
+import tests.BugTrapTest;
 
-public class BugReportTest {
+public class BugReportTest extends BugTrapTest {
 
 	private BugReport bugReport;
 	
@@ -54,10 +55,10 @@ public class BugReportTest {
 	
 	
 	@Before
-	public void setUp() throws Exception {
-		Project project = new Project(null, "n", "d", null, Version.firstVersion(), null, null, 12345, null, null);
-		subsystem = new Subsystem(null, null, null, project, null, project, null);
-		bugReport = new BugReport(null, title, description, subsystem, dependsOn, assignees, comments, issuedBy, creationDate, observers, bugTag, stackTrace, errorMessage, reproduction, targetMilestone, tests, patches, impactFactor);
+	public void setUp() {
+		super.setUp();
+		subsystem = excel;
+		bugReport = new BugReport(bugTrap, title, description, subsystem, dependsOn, assignees, comments, issuedBy, creationDate, observers, bugTag, stackTrace, errorMessage, reproduction, targetMilestone, tests, patches, impactFactor);
 	}
 
 	@Test
@@ -86,21 +87,18 @@ public class BugReportTest {
 	
 	@Test
 	public void assignDeveloperTest() {
-		IUser admin 	= new Administrator(null, null, null, null);
-		IUser issuer 	= new Issuer(null, null, null, null);
-		IUser developer = new Developer(null, null, null, null);
-		
-		try { bugReport.assignDeveloper(admin); fail(); } catch (IllegalArgumentException e) {} catch (UnauthorizedAccessException e) { }
-		try { bugReport.assignDeveloper(issuer); fail(); } catch (IllegalArgumentException e) {} catch (UnauthorizedAccessException e) { }
+		bugTrap.getUserManager().loginAs(lead);
+		try { bugReport.assignDeveloper(admin); fail(); } catch (IllegalArgumentException e) {} catch (UnauthorizedAccessException e) { fail(); }
+		try { bugReport.assignDeveloper(issuer); fail(); } catch (IllegalArgumentException e) {} catch (UnauthorizedAccessException e) { fail(); }
 		
 		assertEquals(0, bugReport.getAssignees().size());
 		try {
-			bugReport.assignDeveloper(developer);
+			bugReport.assignDeveloper(prog);
 		} catch (UnauthorizedAccessException e) {
 			fail();
 		}
 		assertEquals(1, bugReport.getAssignees().size());
-		assertEquals(bugReport.getAssignees().get(0), developer);
+		assertEquals(bugReport.getAssignees().get(0), prog);
 	}
 	
 	@Test
@@ -112,7 +110,9 @@ public class BugReportTest {
 		BugTag notABugTag 		= BugTag.NOTABUG;
 		BugTag resolvedTag 		= BugTag.RESOLVED;
 		BugTag underReviewTag 	= BugTag.UNDERREVIEW;
-		
+
+		bugTrap.getUserManager().loginAs(lead);
+
 		//From New to New is allowed.
 		try {
 			bugReport.updateBugTag(newTag);
@@ -147,8 +147,6 @@ public class BugReportTest {
 			fail();
 		}
 		//Walking around in Closed is not allowed.
-		
-		System.out.println(bugReport.getBugTag());
 		try { bugReport.updateBugTag(resolvedTag); fail(); } catch (IllegalStateException e) { } catch (UnauthorizedAccessException e) { }
 		try { bugReport.updateBugTag(closedTag); fail(); } catch (IllegalStateException e) { } catch (UnauthorizedAccessException e) { }
 		try { bugReport.updateBugTag(notABugTag); fail(); } catch (IllegalStateException e) { } catch (UnauthorizedAccessException e) { }
@@ -161,12 +159,13 @@ public class BugReportTest {
 
 	@Test
 	public void compareTest() {
-		BugReport other = new BugReport(null, "CugReport", null, null, null, null, null, null, null, null, BugTag.NEW, null, null, null, null, null, null, 4);
-		assertEquals(-1, bugReport.compareTo(other));
-		assertEquals(1, other.compareTo(bugReport));
-		
-		BugReport other2 = new BugReport(null, "BugReport", null, null, null, null, null, null, null, null, BugTag.NEW, null, null, null, null, null, null, 3);
-		assertEquals(0, bugReport.compareTo(other2));
-		assertEquals(0, other2.compareTo(bugReport));
+		assertEquals(-1, clippyBug.compareTo(wordBug));
+		assertEquals(1, wordArtBug.compareTo(clippyBug));
+
+		assertEquals(0, bugReport.compareTo(bugReport));
+		assertEquals(0, bugReport.compareTo(bugReport));
+
+		assertEquals(-1, bugReport.compareTo(clippyBug));
+		assertEquals(1, clippyBug.compareTo(bugReport));
 	}
 }

--- a/src/tests/bugreporttests/BugTagTests.java
+++ b/src/tests/bugreporttests/BugTagTests.java
@@ -1,28 +1,68 @@
 package tests.bugreporttests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import controllers.exceptions.UnauthorizedAccessException;
+import model.bugreports.IBugReport;
+import model.bugreports.Patch;
+import model.bugreports.TargetMilestone;
+import model.bugreports.comments.Comment;
+import model.notifications.observers.Observer;
+import model.projects.ISubsystem;
+import model.users.IUser;
+import model.users.Issuer;
 import org.junit.Before;
 import org.junit.Test;
 
 import model.bugreports.BugReport;
 import model.bugreports.bugtag.BugTag;
 import model.bugreports.bugtag.BugTagState;
+import tests.BugTrapTest;
 
-public class BugTagTests {
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class BugTagTests extends BugTrapTest {
 
 	private BugReport bugReport;
-	
+
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
+        super.setUp();
+        String title = "BugReport";
+        String description = "Awesome BugReport";
+        ISubsystem subsystem = excel;
+        List<IBugReport> dependsOn = new ArrayList<>();
+        List<IUser> assignees = new ArrayList<>();
+        List<Comment> comments = new ArrayList<>();
+        List<Observer> observers = new ArrayList<>();
+        IUser issuedBy = new Issuer(null, null, null, null);
+        Date creationDate = new Date();
+        BugTag bugTag = BugTag.NEW;
+        String stackTrace = "stack";
+        String errorMessage = "error";
+        String reproduction = "reproduction";
+        TargetMilestone targetMilestone = new TargetMilestone();
+        List<model.bugreports.Test> tests = new ArrayList<>();
+        List<Patch> patches = new ArrayList<Patch>();
+        int impactFactor = 3;
+        bugReport = new BugReport(bugTrap, title, description, subsystem, dependsOn, assignees, comments, issuedBy, creationDate, observers, bugTag, stackTrace, errorMessage, reproduction, targetMilestone, tests, patches, impactFactor);
+    }
+
+    public void setInitialTag(BugTag tag) {
+        bugTrap.getUserManager().loginAs(lead);
+        try {
+            bugReport.updateBugTag(tag);
+        } catch (UnauthorizedAccessException e) {
+            fail();
+        }
     }
 
     @Test
     public void newTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.NEW, null, null, null, null, null, null, 5);
-        BugTagState tag = bugReport.getBugTagState();
+        setInitialTag(BugTag.NEW);
+    	BugTagState tag = bugReport.getBugTagState();
         assertTrue(tag.isNew());
         assertFalse(tag.isClosed());
         assertFalse(tag.isInProgress());
@@ -31,7 +71,7 @@ public class BugTagTests {
 
     @Test
     public void assignedTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.ASSIGNED, null, null, null, null, null, null, 4);
+        setInitialTag(BugTag.ASSIGNED);
     	BugTagState tag = bugReport.getBugTagState();
         assertFalse(tag.isNew());
         assertFalse(tag.isClosed());
@@ -41,7 +81,7 @@ public class BugTagTests {
 
     @Test
     public void closedTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.CLOSED, null, null, null, null, null, null, 6);
+        setInitialTag(BugTag.CLOSED);
     	BugTagState tag = bugReport.getBugTagState();
         assertTrue(tag.isClosed());
         assertFalse(tag.isNew());
@@ -51,7 +91,7 @@ public class BugTagTests {
 
     @Test
     public void duplicateTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.DUPLICATE, null, null, null, null, null, null, 2);
+        setInitialTag(BugTag.DUPLICATE);
     	BugTagState tag = bugReport.getBugTagState();
         assertTrue(tag.isClosed());
         assertFalse(tag.isNew());
@@ -61,7 +101,7 @@ public class BugTagTests {
 
     @Test
     public void notABugTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.NOTABUG, null, null, null, null, null, null, 6);
+        setInitialTag(BugTag.NOTABUG);
     	BugTagState tag = bugReport.getBugTagState();
         assertFalse(tag.isNew());
         assertFalse(tag.isInProgress());
@@ -71,7 +111,7 @@ public class BugTagTests {
 
     @Test
     public void resolvedTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.RESOLVED, null, null, null, null, null, null, 5);
+        setInitialTag(BugTag.RESOLVED);
     	BugTagState tag = bugReport.getBugTagState();
         assertFalse(tag.isNew());
         assertFalse(tag.isInProgress());
@@ -81,11 +121,571 @@ public class BugTagTests {
 
     @Test
     public void underReviewTest() {
-    	bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.UNDERREVIEW, null, null, null, null, null, null, 9);
+        setInitialTag(BugTag.UNDERREVIEW);
     	BugTagState tag = bugReport.getBugTagState();
         assertFalse(tag.isNew());
         assertTrue(tag.isInProgress());
         assertFalse(tag.isClosed());
         assertEquals(tag.getTag(), BugTag.UNDERREVIEW);
+    }
+
+    // -- Move from NEW to any other tag to make sure tags work correctly --
+    @Test
+    public void updateBugTagNewNew() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+        assertEquals(bugReport.getBugTag(), BugTag.NEW);
+    }
+
+    @Test
+    public void updateBugTagNewAssigned() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+        assertEquals(bugReport.getBugTag(), BugTag.ASSIGNED);
+    }
+
+    @Test
+    public void updateBugTagNewClosed() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+        assertEquals(bugReport.getBugTag(), BugTag.CLOSED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNewClosedNotAllowed() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test
+    public void updateBugTagNewDuplicate() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+        assertEquals(bugReport.getBugTag(), BugTag.DUPLICATE);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNewDuplicateNotAllowed() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test
+    public void updateBugTagNewNotABug() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+        assertEquals(bugReport.getBugTag(), BugTag.NOTABUG);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNewNotABugNotAllowed() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test
+    public void updateBugTagNewResolved() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+        assertEquals(bugReport.getBugTag(), BugTag.RESOLVED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNewResolvedNotAllowed() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test
+    public void updateBugTagNewUnderReview() throws UnauthorizedAccessException {
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+        assertEquals(bugReport.getBugTag(), BugTag.UNDERREVIEW);
+    }
+
+
+    // -- Move from ASSIGNED to any other tag to make sure tags work correctly --
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagAssignedNew() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+    }
+
+    @Test
+    public void updateBugTagAssignedAssigned() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+        assertEquals(bugReport.getBugTag(), BugTag.ASSIGNED);
+    }
+
+    @Test
+    public void updateBugTagAssignedClosed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+        assertEquals(bugReport.getBugTag(), BugTag.CLOSED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagAssignedClosedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test
+    public void updateBugTagAssignedDuplicate() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+        assertEquals(bugReport.getBugTag(), BugTag.DUPLICATE);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagAssignedDuplicateNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test
+    public void updateBugTagAssignedNotABug() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+        assertEquals(bugReport.getBugTag(), BugTag.NOTABUG);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagAssignedNotABugNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test
+    public void updateBugTagAssignedResolved() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+        assertEquals(bugReport.getBugTag(), BugTag.RESOLVED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagAssignedResolvedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test
+    public void updateBugTagAssignedUnderReview() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.ASSIGNED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+        assertEquals(bugReport.getBugTag(), BugTag.UNDERREVIEW);
+    }
+
+
+    // -- Move from CLOSED to any other tag to make sure tags work correctly --
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedNew() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedAssigned() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedClosed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagClosedClosedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedDuplicate() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagClosedDuplicateNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedNotABug() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagClosedNotABugNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedResolved() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagClosedResolvedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagClosedUnderReview() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.CLOSED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+    }
+
+
+    // -- Move from DUPLICATE to any other tag to make sure tags work correctly --
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateNew() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateAssigned() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateClosed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagDuplicateClosedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateDuplicate() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagDuplicateDuplicateNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateNotABug() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagDuplicateNotABugNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateResolved() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagDuplicateResolvedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagDuplicateUnderReview() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.DUPLICATE);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+    }
+
+
+    // -- Move from NOTABUG to any other tag to make sure tags work correctly --
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugNew() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugAssigned() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugClosed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNotABugClosedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugDuplicate() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNotABugDuplicateNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugNotABug() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNotABugNotABugNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugResolved() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagNotABugResolvedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagNotABugUnderReview() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.NOTABUG);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+    }
+
+
+    // -- Move from RESOLVED to any other tag to make sure tags work correctly --
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedNew() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedAssigned() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedClosed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagResolvedClosedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedDuplicate() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagResolvedDuplicateNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedNotABug() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagResolvedNotABugNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedResolved() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagResolvedResolvedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagResolvedUnderReview() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.RESOLVED);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+    }
+
+
+    // -- Move from UNDERREVIEW to any other tag to make sure tags work correctly --
+    @Test (expected = IllegalStateException.class)
+    public void updateBugTagUnderReviewNew() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NEW);
+    }
+
+    @Test
+    public void updateBugTagUnderReviewAssigned() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.ASSIGNED);
+        assertEquals(BugTag.ASSIGNED, bugReport.getBugTag());
+    }
+
+    @Test
+    public void updateBugTagUnderReviewClosed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.CLOSED);
+        assertEquals(BugTag.CLOSED, bugReport.getBugTag());
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagUnderReviewClosedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.CLOSED);
+    }
+
+    @Test
+    public void updateBugTagUnderReviewDuplicate() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+        assertEquals(BugTag.DUPLICATE, bugReport.getBugTag());
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagUnderReviewDuplicateNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.DUPLICATE);
+    }
+
+    @Test
+    public void updateBugTagUnderReviewNotABug() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+        assertEquals(BugTag.NOTABUG, bugReport.getBugTag());
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagUnderReviewNotABugNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.NOTABUG);
+    }
+
+    @Test
+    public void updateBugTagUnderReviewResolved() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+        assertEquals(BugTag.RESOLVED, bugReport.getBugTag());
+    }
+
+    @Test (expected = UnauthorizedAccessException.class)
+    public void updateBugTagUnderReviewResolvedNotAllowed() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(issuer);
+        bugReport.updateBugTag(BugTag.RESOLVED);
+    }
+
+    @Test
+    public void updateBugTagUnderReviewUnderReview() throws UnauthorizedAccessException {
+        setInitialTag(BugTag.UNDERREVIEW);
+        bugTrap.getUserManager().loginAs(lead);
+        bugReport.updateBugTag(BugTag.UNDERREVIEW);
+        assertEquals(BugTag.UNDERREVIEW, bugReport.getBugTag());
     }
 }

--- a/src/tests/bugreporttests/CommentTest.java
+++ b/src/tests/bugreporttests/CommentTest.java
@@ -10,15 +10,20 @@ import org.junit.Test;
 import model.bugreports.BugReport;
 import model.bugreports.bugtag.BugTag;
 import model.bugreports.comments.Comment;
+import tests.BugTrapTest;
 
-public class CommentTest {
+import java.util.Date;
+
+public class CommentTest extends BugTrapTest {
 
 	Comment comment;
 	String text = "This is a comment.";
-	BugReport bugReport = new BugReport(null, null, null, null, null, null, null, null, null, null, BugTag.NEW, null, null, null, null, null, null, 5);
+
 	@Before
-	public void setUp() throws Exception {
-		comment = new Comment(bugReport, text);
+	public void setUp() {
+		super.setUp();
+		comment = new Comment((BugReport) wordArtBug, text);
+		comment.terminate();
 	}
 
 	@Test
@@ -26,6 +31,8 @@ public class CommentTest {
 		assertTrue(text.equals(comment.getText()));
 		assertNotNull(comment.getCreationDate());
 		assertNotNull(comment.getComments());
+		assertEquals(0, comment.getComments().size());
+		assertTrue(Math.abs(comment.getCreationDate().getTime() - new Date().getTime()) < 500);
 	}
 	
 	@Test
@@ -35,4 +42,26 @@ public class CommentTest {
 		assertEquals(1, comment.getComments().size());
 	}
 
+	@Test
+	public void terminateTest() {
+		comment.addComment("Comment 1");
+		Comment subComment = comment.getComments().get(0);
+		comment.addComment("Comment 2");
+		Comment subComment2 = comment.getComments().get(1);
+		subComment.addComment("Subcomment 1.1");
+		Comment subsubComment11 = subComment.getComments().get(0);
+		subComment.addComment("Subcomment 1.2");
+		Comment subsubComment12 = subComment.getComments().get(1);
+		subComment2.addComment("Subcomment 2.1");
+		subComment2.addComment("Subcomment 2.2");
+		subComment2.addComment("Subcomment 2.3");
+		subComment2.addComment("Subcomment 2.4");
+
+		comment.terminate();
+		assertEquals(0, comment.getComments().size());
+		assertEquals(0, subComment.getComments().size());
+		assertEquals(0, subsubComment11.getComments().size());
+		assertEquals(0, subsubComment12.getComments().size());
+		assertEquals(0, subComment2.getComments().size());
+	}
 }

--- a/src/tests/notificationtests/MailboxTests.java
+++ b/src/tests/notificationtests/MailboxTests.java
@@ -10,14 +10,16 @@ import org.junit.Test;
 import model.notifications.INotification;
 import model.notifications.Mailbox;
 import model.users.Administrator;
+import tests.BugTrapTest;
 
-public class MailboxTests {
+public class MailboxTests extends BugTrapTest {
 	
 	private Mailbox mailbox;
 	
 	@Before
-	public void setUp() throws Exception {
-		mailbox = new Mailbox(new Administrator("","","","ADMIN"));
+	public void setUp() {
+		super.setUp();
+		mailbox = new Mailbox(admin);
 		
 		mailbox.addNotification("not1");
 		mailbox.addNotification("not2");
@@ -25,14 +27,12 @@ public class MailboxTests {
 	
 	@Test
 	public void addNotificationTest(){
-		int nbnot = mailbox.getNotifications().size();
-		assertEquals(2,nbnot);
+		assertEquals(2, mailbox.getNotifications().size());
 		
 		mailbox.addNotification("not3");
-		
-		nbnot = mailbox.getNotifications().size();
-		assertEquals(3,nbnot);
-		assertEquals("not3",mailbox.getNotifications().get(0).getText());
+
+		assertEquals(3, mailbox.getNotifications().size());
+		assertEquals("not3", mailbox.getNotifications().get(0).getText());
 	}
 	
 	@Test
@@ -43,9 +43,8 @@ public class MailboxTests {
 		mailbox.addNotification("not3");
 		
 		List<INotification> list = mailbox.getNotifications(2);
-		assertEquals(2,list.size());
+		assertEquals(2, list.size());
 		assertEquals("not3",list.get(0).getText());
 		assertEquals("not2",list.get(1).getText());
 	}
-
 }

--- a/src/tests/notificationtests/NotificationTests.java
+++ b/src/tests/notificationtests/NotificationTests.java
@@ -8,19 +8,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 import model.notifications.Notification;
+import tests.BugTrapTest;
 
-public class NotificationTests {
+public class NotificationTests extends BugTrapTest {
 	
 	private Notification not;
 	
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
+		super.setUp();
 		not = new Notification("not");
 	}
 	
 	@Test
 	public void constructorTest(){
-		assertEquals("not",not.getText());
+		not = new Notification("not");
+		assertEquals("not", not.getText());
 		assertFalse(not.isRead());
 	}
 	

--- a/src/tests/projecttests/HealthIndicatorTests.java
+++ b/src/tests/projecttests/HealthIndicatorTests.java
@@ -42,7 +42,7 @@ public class HealthIndicatorTests extends BugTrapTest{
 		indicators = subsystem.getHealthIndicators();
 		
 		assertEquals("Word Art", subsystem.getName());
-		assertEquals(0, ((System) subsystem).getBugImpact(), 0.1);
+		assertEquals(6, ((System) subsystem).getBugImpact(), 0.1);
 		assertEquals(HealthIndicator.HEALTHY,indicators.get(0));
 		assertEquals(HealthIndicator.HEALTHY,indicators.get(1));
 		assertEquals(HealthIndicator.HEALTHY,indicators.get(2));
@@ -70,9 +70,9 @@ public class HealthIndicatorTests extends BugTrapTest{
 	public void HealthIndicatorTest2() {
 		//Add BugReports.
 	    bugTrap.getUserManager().loginAs(lead);
-	    bugTrap.getBugReportManager().addBugReport("Bug1", "...", new Date(1303), word, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, 100);
-	    bugTrap.getBugReportManager().addBugReport("Bug2", "...", new Date(1305), word, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, 100);
-	    bugTrap.getBugReportManager().addBugReport("Bug3", "...", new Date(1305), clippy, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, 100);
+	    bugTrap.getBugReportManager().addBugReport("Bug1", "...", new Date(1303), word, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, null, 100);
+	    bugTrap.getBugReportManager().addBugReport("Bug2", "...", new Date(1305), word, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, null, 100);
+	    bugTrap.getBugReportManager().addBugReport("Bug3", "...", new Date(1305), clippy, lead, new ArrayList<>(), new ArrayList<>(), BugTag.NEW, null, 100);
 
 	    //Log off.
 	    bugTrap.getUserManager().logOff();

--- a/src/tests/projecttests/ProjectManagerTests.java
+++ b/src/tests/projecttests/ProjectManagerTests.java
@@ -18,30 +18,16 @@ import model.projects.Role;
 import model.projects.Version;
 import model.users.IUser;
 import model.users.UserManager;
+import tests.BugTrapTest;
 
-public class ProjectManagerTests {
-
-    private BugTrap bugTrap;
-
-    @Before
-    public void setUp() throws Exception {
-    	//New Bugtrap system.
-        bugTrap = new BugTrap();
-        
-        //Create Administrator/Developer.
-        bugTrap.getUserManager().createAdmin("", "", "", "ADMIN");
-        bugTrap.getUserManager().createDeveloper("", "", "", "DEV");
-        
-        //Log in with Administrator.
-        bugTrap.getUserManager().loginAs(bugTrap.getUserManager().getUser("ADMIN"));
-    }
+public class ProjectManagerTests extends BugTrapTest {
 
     @SuppressWarnings("deprecation")
     @Test
     public void testCreateProject() throws UnauthorizedAccessException {
     	
     	bugTrap.getProjectManager().createProject("New Project", "Description", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
-        Project project = (Project) bugTrap.getProjectManager().getProjects().get(0);
+        Project project = (Project) bugTrap.getProjectManager().getProjects().get(bugTrap.getProjectManager().getProjects().size() - 1);
 
         //System variables.
         assertEquals("New Project", 		project.getName());
@@ -61,70 +47,59 @@ public class ProjectManagerTests {
     @SuppressWarnings("deprecation")
     @Test
     public void testCreateFork() {
-    	IProject project = null;
-        IProject fork = null;
+    	IProject fork = null;
         		
-        //Make a Project as usual.
-        bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(2, 1, 0));
-        project = bugTrap.getProjectManager().getProjects().get(0);
-
-        //Three cases where fork's Version isn't incremented.
+        //cases where fork's Version isn't incremented.
         try {
-            bugTrap.getProjectManager().createFork(project, 123592929, new Version(1, 0, 0), new Date(2016, 1 , 1));
+            bugTrap.getProjectManager().createFork(office, 123592929, new Version(0, 9, 0), new Date(2016, 1 , 1));
             fail("Fork version should be higher than original Version");
-        } catch(Exception e) { }
+        } catch(IllegalArgumentException e) { }
         try {
-            bugTrap.getProjectManager().createFork(project, 123592929, new Version(2, 1, 0), new Date(2016, 1 , 1));
+            bugTrap.getProjectManager().createFork(office, 123592929, new Version(1, 0, 0), new Date(2016, 1 , 1));
             fail("Fork version should be higher than original Version");
-        } catch(Exception e) { }
+        } catch(IllegalArgumentException e) { }
 
         //Version is actually incremented.
-        bugTrap.getProjectManager().createFork(project, 123592929, new Version(2, 1, 1), new Date(2016, 1, 1));
+        bugTrap.getProjectManager().createFork(office, 123592929, new Version(2, 1, 1), new Date(2016, 1, 1));
         fork = bugTrap.getProjectManager().getProjects().get(1);
 
-        Assert.assertTrue(project.equals(fork));
+        Assert.assertTrue(office.equals(fork));
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testUpdateProject() {
-        IProject project = null;
-		bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
-		project = bugTrap.getProjectManager().getProjects().get(0);
+        bugTrap.getProjectManager().updateProject(office, "nn", "dd", 3883, new Date(2015, 11, 1));
 
-        UserManager um = new UserManager();
-        um.createDeveloper("", "", "", "D");
-        bugTrap.getProjectManager().updateProject(project, "nn", "dd", 3883, new Date(2015, 11, 1));
-
-        Assert.assertEquals(project.getName(), "nn");
-        Assert.assertEquals(project.getDescription(), "dd");
-        Assert.assertEquals(project.getStartDate(), new Date(2015, 11, 1));
-        Assert.assertEquals(project.getBudgetEstimate(), 3883, 0.0001);
+        Assert.assertEquals(office.getName(), "nn");
+        Assert.assertEquals(office.getDescription(), "dd");
+        Assert.assertEquals(office.getStartDate(), new Date(2015, 11, 1));
+        Assert.assertEquals(office.getBudgetEstimate(), 3883, 0.0001);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testDeleteProject() throws UnauthorizedAccessException {
-    	bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
-        
-    	bugTrap.getProjectManager().deleteProject(bugTrap.getProjectManager().getProjects().get(0));
+        int projects = bugTrap.getProjectManager().getProjects().size();
 
-        Assert.assertEquals(bugTrap.getProjectManager().getProjects().size(), 0);
+    	bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
+        IProject project = bugTrap.getProjectManager().getProjects().get(projects);
+        Assert.assertEquals(bugTrap.getProjectManager().getProjects().size(), projects + 1);
+
+    	bugTrap.getProjectManager().deleteProject(project);
+        Assert.assertEquals(bugTrap.getProjectManager().getProjects().size(), projects);
+        Assert.assertFalse(bugTrap.getProjectManager().getProjects().contains(project));
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testAssignToProject() {
-    	
-        IProject project = null;
-		bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
-		project = bugTrap.getProjectManager().getProjects().get(0);
+        bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
+        IProject project = bugTrap.getProjectManager().getProjects().get(bugTrap.getProjectManager().getProjects().size() - 1);
+        //to assign, need to be logged in as dev
+		bugTrap.getUserManager().loginAs(lead);
 
-		//to assign, need to be logged in as dev
-		IUser dev =  bugTrap.getUserManager().getUser("DEV");
-    	bugTrap.getUserManager().loginAs(dev);
-    	
-		
+
         UserManager um = new UserManager();
         um.createDeveloper("", "", "", "D0");
         IUser d0 = um.getDevelopers().get(0);
@@ -133,15 +108,15 @@ public class ProjectManagerTests {
         um.createDeveloper("", "", "", "D2");
         IUser d2 = um.getDevelopers().get(2);
 
-        bugTrap.getProjectManager().assignToProject(project, d0, Role.PROGRAMMER);
-		Assert.assertTrue(project.getProgrammers().contains(d0));
-        Assert.assertFalse(project.getProgrammers().contains(d1));
-        Assert.assertFalse(project.getProgrammers().contains(d2));
+        bugTrap.getProjectManager().assignToProject(office, d0, Role.PROGRAMMER);
+		Assert.assertTrue(office.getProgrammers().contains(d0));
+        Assert.assertFalse(office.getProgrammers().contains(d1));
+        Assert.assertFalse(office.getProgrammers().contains(d2));
 
-        bugTrap.getProjectManager().assignToProject(project, d1, Role.TESTER);
-		Assert.assertFalse(project.getTesters().contains(d0));
-        Assert.assertTrue(project.getTesters().contains(d1));
-        Assert.assertFalse(project.getTesters().contains(d2));
+        bugTrap.getProjectManager().assignToProject(office, d1, Role.TESTER);
+		Assert.assertFalse(office.getTesters().contains(d0));
+        Assert.assertTrue(office.getTesters().contains(d1));
+        Assert.assertFalse(office.getTesters().contains(d2));
 
         bugTrap.getProjectManager().assignToProject(project, d2, Role.LEAD);
 		Assert.assertNotEquals(project.getLeadDeveloper(), d0);
@@ -160,6 +135,8 @@ public class ProjectManagerTests {
         um.createDeveloper("", "", "", "D3");
         IUser d3 = um.getDevelopers().get(2);
 
+        int projects = bugTrap.getProjectManager().getProjects().size();
+
         IProject p1 = null;
         IProject p2 = null;
         IProject p3 = null;
@@ -167,9 +144,9 @@ public class ProjectManagerTests {
         bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, d1, new Version(1, 0, 0));
         bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, d2, new Version(1, 0, 0));
         bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, d3, new Version(1, 0, 0));
-        p1 = bugTrap.getProjectManager().getProjects().get(0);
-        p2 = bugTrap.getProjectManager().getProjects().get(1);
-        p3 = bugTrap.getProjectManager().getProjects().get(2);
+        p1 = bugTrap.getProjectManager().getProjects().get(projects);
+        p2 = bugTrap.getProjectManager().getProjects().get(projects+1);
+        p3 = bugTrap.getProjectManager().getProjects().get(projects+2);
 
         bugTrap.getUserManager().loginAs(d1);
         Assert.assertTrue(bugTrap.getProjectManager().getProjectsForSignedInLeadDeveloper().contains(p1));
@@ -187,49 +164,40 @@ public class ProjectManagerTests {
         Assert.assertFalse(bugTrap.getProjectManager().getProjectsForSignedInLeadDeveloper().contains(p2));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testCreateSubsystem() {
-
-        IProject project = null;
         ISubsystem sub = null;
-        bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
-        project = bugTrap.getProjectManager().getProjects().get(0);
-        bugTrap.getProjectManager().createSubsystem("name", "description", project, project);
+        bugTrap.getProjectManager().createSubsystem("name", "description", office, office);
         sub = bugTrap.getProjectManager().getSubsystemWithName("name");
 
         Assert.assertEquals(sub.getName(), "name");
         Assert.assertEquals(sub.getDescription(), "description");
-        Assert.assertEquals(sub.getProject(), project);
-        Assert.assertEquals(sub.getParent(), project);
+        Assert.assertEquals(sub.getProject(), office);
+        Assert.assertEquals(sub.getParent(), office);
         Assert.assertEquals(sub.getSubsystems().size(), 0);
-        Assert.assertTrue(project.getSubsystems().contains(sub));
+        Assert.assertTrue(office.getSubsystems().contains(sub));
 
         ISubsystem subsub = null;
-		bugTrap.getProjectManager().createSubsystem("name2", "descr2", project, sub);
+		bugTrap.getProjectManager().createSubsystem("name2", "descr2", office, sub);
 		subsub = bugTrap.getProjectManager().getSubsystemWithName("name2");
 
         Assert.assertEquals(subsub.getName(), "name2");
         Assert.assertEquals(subsub.getDescription(), "descr2");
-        Assert.assertEquals(subsub.getProject(), project);
+        Assert.assertEquals(subsub.getProject(), office);
         Assert.assertEquals(subsub.getParent(), sub);
         Assert.assertEquals(subsub.getSubsystems().size(), 0);
         Assert.assertTrue(sub.getSubsystems().contains(subsub));
 
         Assert.assertEquals(sub.getSubsystems().size(), 1);
-        Assert.assertTrue(project.getAllDirectOrIndirectSubsystems().contains(subsub));
-        Assert.assertFalse(project.getSubsystems().contains(subsub));
+        Assert.assertTrue(office.getAllDirectOrIndirectSubsystems().contains(subsub));
+        Assert.assertFalse(office.getSubsystems().contains(subsub));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testGetSubsystemWithName() {
-        IProject project;
-		bugTrap.getProjectManager().createProject("n", "d", new Date(2015, 8, 18), new Date(2015, 9, 1), 123, null, new Version(1, 0, 0));
-			
-        project = bugTrap.getProjectManager().getProjects().get(0);
-        bugTrap.getProjectManager().createSubsystem("name", "description", project, project);
-
-        Assert.assertEquals(bugTrap.getProjectManager().getSubsystemWithName("name").getName(), "name");
+        bugTrap.getProjectManager().createSubsystem("name", "description", office, office);
+        ISubsystem sub = office.getSubsystems().get(office.getSubsystems().size() - 1);
+        assertEquals(bugTrap.getProjectManager().getSubsystemWithName("name").getName(), "name");
+        assertEquals(bugTrap.getProjectManager().getSubsystemWithName("name"), sub);
     }
 }

--- a/src/tests/projecttests/ProjectTeamTests.java
+++ b/src/tests/projecttests/ProjectTeamTests.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import model.projects.ProjectTeam;
 import model.projects.Role;
 import model.users.Developer;
+import tests.BugTrapTest;
 
 public class ProjectTeamTests {
 
@@ -22,7 +23,7 @@ public class ProjectTeamTests {
     Developer tester;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         team1 = new ProjectTeam();
         lead = new Developer("", "", "", "lead");
         prog = new Developer("", "", "", "prog");

--- a/src/tests/projecttests/ProjectTests.java
+++ b/src/tests/projecttests/ProjectTests.java
@@ -3,6 +3,7 @@ package tests.projecttests;
 import java.util.ArrayList;
 import java.util.Date;
 
+import model.users.Developer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,13 +12,11 @@ import model.projects.Project;
 import model.projects.ProjectTeam;
 import model.projects.Subsystem;
 import model.projects.Version;
+import tests.BugTrapTest;
 
-public class ProjectTests {
+import static org.junit.Assert.*;
 
-    @Before
-    public void setUp() throws Exception {
-
-    }
+public class ProjectTests extends BugTrapTest {
 
     @SuppressWarnings("deprecation")
     @Test
@@ -33,4 +32,22 @@ public class ProjectTests {
         Assert.assertEquals(p.getStartDate(), new Date(2013, 1, 1));
         Assert.assertEquals(p.getBudgetEstimate(), 12345, 0.0000001);
     }
+
+    @Test
+    public void testAddProgrammer() {
+        Developer dev = bugTrap.getUserManager().createDeveloper("D", "E", "V", "developer");
+        office.addProgrammer(dev);
+        assertTrue(office.getProgrammers().contains(dev));
+        assertFalse(office.getTesters().contains(dev));
+        assertNotEquals(office.getLeadDeveloper(), dev);
+    }
+
+     @Test
+    public void testAddTester() {
+         Developer dev = bugTrap.getUserManager().createDeveloper("D", "E", "V", "developer");
+         office.addTester(dev);
+         assertFalse(office.getProgrammers().contains(dev));
+         assertTrue(office.getTesters().contains(dev));
+         assertNotEquals(office.getLeadDeveloper(), dev);
+     }
 }

--- a/src/tests/projecttests/SystemTests.java
+++ b/src/tests/projecttests/SystemTests.java
@@ -1,65 +1,97 @@
 package tests.projecttests;
 
 import java.util.ArrayList;
+import java.util.Date;
 
+import controllers.exceptions.UnauthorizedAccessException;
+import model.bugreports.BugReport;
+import model.bugreports.bugtag.BugTag;
+import model.notifications.Mailbox;
+import model.notifications.observers.BugReportChangeObserver;
+import model.notifications.observers.Observer;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import model.projects.Project;
-import model.projects.ProjectTeam;
+import model.projects.System;
 import model.projects.Subsystem;
 import model.projects.Version;
+import tests.BugTrapTest;
 
-public class SystemTests {
-    private Project sys;
-    private Subsystem subsys;
-    private Subsystem subsubsys;
-    private Subsystem subsys2;
+import static org.junit.Assert.*;
 
-    @Before
-    public void setUp() throws Exception {
-        sys 		= new Project(null, "", "", new ArrayList<Subsystem>(), Version.firstVersion(), null, null, 12345, new ProjectTeam(), null);
-        subsys 		= new Subsystem(null, "", "", sys, new ArrayList<Subsystem>(), sys, null);
-        subsubsys	= new Subsystem(null, "", "", subsys, new ArrayList<Subsystem>(), sys, null);
-        subsys2 	= new Subsystem(null, "", "", sys, new ArrayList<Subsystem>(), sys, null);
-    }
-
-    @Test
-    public void testSetUp(){
-        Assert.assertEquals(subsys.getParent(), sys);
-        Assert.assertEquals(subsys2.getParent(), sys);
-        Assert.assertEquals(subsys.getSubsystems().size(), 1);
-        Assert.assertEquals(sys.getSubsystems().size(), 2);
-        Assert.assertEquals(sys.getVersion(), Version.firstVersion());
-    }
+public class SystemTests extends BugTrapTest {
 
     @Test
     public void testAddSubsystem() {
-        Subsystem s = new Subsystem(null, "sub", "descr", subsubsys, new ArrayList<Subsystem>(), sys, null	);
+        Subsystem s = new Subsystem(bugTrap, "sub", "descr", (Subsystem)word, new ArrayList<>(), (Project)office, null);
 
-        Assert.assertEquals(s.getParent(), subsubsys);
+        Assert.assertEquals(s.getParent(), word);
         Assert.assertEquals(s.getSubsystems().size(), 0);
-        Assert.assertFalse(subsys.getSubsystems().contains(s));
-        Assert.assertTrue(subsys.getAllDirectOrIndirectSubsystems().contains(s));
-        Assert.assertTrue(subsubsys.getSubsystems().contains(s));
+        Assert.assertFalse(office.getSubsystems().contains(s));
+        assertTrue(office.getAllDirectOrIndirectSubsystems().contains(s));
+        assertTrue(word.getSubsystems().contains(s));
     }
 
     @Test
     public void testEquals() {
-       // Assert.assertFalse(subsys.equals(subsys2)); // Different amount of subsystems
-        Assert.assertTrue(subsys2.equals(new Subsystem(null, "", "", sys, new ArrayList<Subsystem>(), sys, null)));
+        assertTrue(powerpoint.equals(new Subsystem(bugTrap, "PowerPoint", "Powerfully pointless", (System)office, null, (Project)office, null)));
         // Compare "identical" Projects but with different subs
-        Project p2 = new Project(null, "", "", new ArrayList<Subsystem>(), Version.firstVersion(), null, null, 12345, null, null);
-        Assert.assertFalse(sys.equals(p2));
+        Project p2 = new Project(bugTrap, "Office", "This project is huge. Lots of subsystems", new ArrayList<Subsystem>(), Version.firstVersion(), new Date(1302), new Date(1302), 12345, null, null);
+        assertFalse(office.equals(p2));
 
         Project projA = new Project(null, "n", "d", new ArrayList<Subsystem>(), Version.firstVersion(), null, null, 12345, null, null);
         Project projB = new Project(null, "n", "d", new ArrayList<Subsystem>(), Version.firstVersion(), null, null, 12345, null, null);
         Subsystem subA = new Subsystem(null, "", "", projA, new ArrayList<Subsystem>(), projA, null);
         Subsystem subB = new Subsystem(null, "", "", projB, new ArrayList<Subsystem>(), projB, null);
-        Assert.assertTrue(projA.equals(projB));
+        assertTrue(projA.equals(projB));
         Assert.assertEquals(projA, projB);
-        Assert.assertTrue(subA.equals(subB));
+        assertTrue(subA.equals(subB));
         Assert.assertEquals(subA, subB);
+    }
+
+    @Test
+    public void testAttachDetach() throws UnauthorizedAccessException {
+        Mailbox box = bugTrap.getNotificationManager().getMailboxForUser(admin);
+        int notificationCount = box.getNotifications().size();
+        Observer o = new BugReportChangeObserver(box, office);
+        office.attach(o);
+
+        bugTrap.getUserManager().loginAs(lead);
+        ((BugReport)wordArtBug).updateBugTag(BugTag.CLOSED);
+        // Attached, so should drop a new notification in the mailbox
+        assertEquals(notificationCount + 1, box.getNotifications().size());
+
+        office.detach(o);
+        ((BugReport)clippyBug).updateBugTag(BugTag.CLOSED);
+        // Detached, so notification count should stay the same
+        assertEquals(notificationCount + 1, box.getNotifications().size());
+    }
+
+    @Test
+    public void testGetBugReports() {
+        assertTrue(office.getAllBugReports().contains(wordBug));
+        assertTrue(office.getAllBugReports().contains(wordArtBug));
+        assertTrue(office.getAllBugReports().contains(clippyBug));
+
+        assertTrue(word.getAllBugReports().contains(wordBug));
+        assertTrue(word.getAllBugReports().contains(wordArtBug));
+        assertTrue(word.getAllBugReports().contains(clippyBug));
+        assertFalse(excel.getAllBugReports().contains(wordBug));
+        assertFalse(excel.getAllBugReports().contains(wordArtBug));
+        assertFalse(excel.getAllBugReports().contains(clippyBug));
+        assertFalse(powerpoint.getAllBugReports().contains(wordBug));
+        assertFalse(powerpoint.getAllBugReports().contains(wordArtBug));
+        assertFalse(powerpoint.getAllBugReports().contains(clippyBug));
+
+        assertFalse(wordArt.getAllBugReports().contains(wordBug));
+        assertTrue(wordArt.getAllBugReports().contains(wordArtBug));
+        assertFalse(wordArt.getAllBugReports().contains(clippyBug));
+        assertFalse(comicSans.getAllBugReports().contains(wordBug));
+        assertFalse(comicSans.getAllBugReports().contains(wordArtBug));
+        assertFalse(comicSans.getAllBugReports().contains(clippyBug));
+        assertFalse(clippy.getAllBugReports().contains(wordBug));
+        assertFalse(clippy.getAllBugReports().contains(wordArtBug));
+        assertTrue(clippy.getAllBugReports().contains(clippyBug));
     }
 }

--- a/src/tests/projecttests/VersionTests.java
+++ b/src/tests/projecttests/VersionTests.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import model.projects.Version;
+import tests.BugTrapTest;
 
 public class VersionTests {
 	
@@ -14,7 +15,7 @@ public class VersionTests {
 	Version version4;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		version1 = new Version(1, 0, 0);
 		version2 = new Version(1, 0, 1);
 		version3 = new Version(1, 1, 0);
@@ -59,5 +60,4 @@ public class VersionTests {
 	public void equalsFailTest() {
 		Assert.assertFalse(version1.equals(null));
 	}
-
 }

--- a/src/tests/usertests/UserManagerTests.java
+++ b/src/tests/usertests/UserManagerTests.java
@@ -1,5 +1,6 @@
 package tests.usertests;
 
+import model.users.Administrator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -10,33 +11,14 @@ import model.users.IUser;
 import model.users.UserManager;
 import model.users.exceptions.NoUserWithUserNameException;
 import model.users.exceptions.NotUniqueUserNameException;
+import tests.BugTrapTest;
 
-public class UserManagerTests {
-	
-	private UserManager userManager;
-	private IUser admin;
-	private IUser issuer;
-	private IUser dev;
-
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-	}
-
-	@Before
-	public void setUp() throws Exception {
-		userManager = new UserManager();
-		
-		userManager.createAdmin("Richard", "Rosie", "Reese", "RRR");
-		userManager.createIssuer("Lindsey", "Lida", "Linkovic", "LLL");
-		userManager.createDeveloper("Carl", "Casey", "Carver", "CCC");
-		
-		admin = userManager.getAdmins().get(0);
-		issuer = userManager.getIssuers().get(0);
-		dev = userManager.getDevelopers().get(0);
-	}
+public class UserManagerTests extends BugTrapTest {
 
 	@Test
 	public void adminCreateTest() {
+		bugTrap.getUserManager().createAdmin("Richard", "Rosie", "Reese", "RRR");
+		IUser admin = bugTrap.getUserManager().getAdmins().get(bugTrap.getUserManager().getAdmins().size() - 1);
 		Assert.assertTrue(admin.isAdmin());
 		Assert.assertEquals(admin.getFirstName(), "Richard");
 		Assert.assertEquals(admin.getMiddleName(), "Rosie");
@@ -46,6 +28,8 @@ public class UserManagerTests {
 	
 	@Test
 	public void issuerCreateTest() {
+		bugTrap.getUserManager().createIssuer("Lindsey", "Lida", "Linkovic", "LLL");
+		IUser issuer = bugTrap.getUserManager().getIssuers().get(bugTrap.getUserManager().getIssuers().size() - 1);
 		Assert.assertTrue(issuer.isIssuer());
 		Assert.assertEquals(issuer.getFirstName(), "Lindsey");
 		Assert.assertEquals(issuer.getMiddleName(), "Lida");
@@ -55,6 +39,8 @@ public class UserManagerTests {
 	
 	@Test
 	public void devCreateTest() {
+		bugTrap.getUserManager().createDeveloper("Carl", "Casey", "Carver", "CCC");
+		IUser dev = bugTrap.getUserManager().getDevelopers().get(bugTrap.getUserManager().getDevelopers().size() - 1);
 		Assert.assertTrue(dev.isDeveloper());
 		Assert.assertEquals(dev.getFirstName(), "Carl");
 		Assert.assertEquals(dev.getMiddleName(), "Casey");
@@ -64,96 +50,96 @@ public class UserManagerTests {
 	
 	@Test (expected = NotUniqueUserNameException.class)
 	public void createAdminFailUserNameExistsTest() {
-		userManager.createAdmin("", "", "", "RRR");
+		bugTrap.getUserManager().createAdmin("", "", "", "ADMIN");
 	}
 	
 	@Test (expected = NotUniqueUserNameException.class)
 	public void createIssuerFailUserNameExistsTest() {
-		userManager.createIssuer("", "", "", "RRR");
+		bugTrap.getUserManager().createIssuer("", "", "", "ISSUER");
 	}
 	
 	@Test (expected = NotUniqueUserNameException.class)
 	public void createDeveloperFailUserNameExistsTest() {
-		userManager.createDeveloper("", "", "", "RRR");
+		bugTrap.getUserManager().createDeveloper("", "", "", "TESTER");
 	}
 	
 	@Test
 	public void loginSuccesTest() {
-		Assert.assertFalse(userManager.isLoggedIn(admin));
-		String message = userManager.loginAs(admin);
-		Assert.assertEquals("User: RRR successfully logged in.", message);
-		Assert.assertTrue(userManager.isLoggedIn(admin));
-		message = userManager.loginAs(admin);
-		Assert.assertEquals("User: RRR is already logged in.", message);
-		Assert.assertTrue(userManager.isLoggedIn(admin));
-		Assert.assertFalse(userManager.isLoggedIn(dev));
+		Assert.assertFalse(bugTrap.getUserManager().isLoggedIn(admin));
+		String message = bugTrap.getUserManager().loginAs(admin);
+		Assert.assertEquals("User: ADMIN successfully logged in.", message);
+		Assert.assertTrue(bugTrap.getUserManager().isLoggedIn(admin));
+		message = bugTrap.getUserManager().loginAs(admin);
+		Assert.assertEquals("User: ADMIN is already logged in.", message);
+		Assert.assertTrue(bugTrap.getUserManager().isLoggedIn(admin));
+		Assert.assertFalse(bugTrap.getUserManager().isLoggedIn(lead));
 	}
 	
 	@Test (expected = NoUserWithUserNameException.class)
 	public void loginFailTest() {
 		Developer d = new Developer("", "", "", "");
-		userManager.loginAs(d);
+		bugTrap.getUserManager().loginAs(d);
 	}
 	
 	@Test
 	public void userNameExistsTest() {
-		boolean succes = userManager.userNameExists("RRR");
-		boolean fail = userManager.userNameExists("NotExistingUser");
+		boolean succes = bugTrap.getUserManager().userNameExists("ADMIN");
+		boolean fail = bugTrap.getUserManager().userNameExists("NotExistingUser");
 		Assert.assertTrue(succes);
 		Assert.assertFalse(fail);
 	}
 	
 	@Test
 	public void userExistsTest() {
-		boolean succes = userManager.userExists(admin);
-		boolean fail = userManager.userExists(new Developer("", "", "",""));
+		boolean succes = bugTrap.getUserManager().userExists(admin);
+		boolean fail = bugTrap.getUserManager().userExists(new Developer("", "", "",""));
 		Assert.assertTrue(succes);
 		Assert.assertFalse(fail);
 	}
 	
 	@Test
 	public void getAdminsTest() {
-		int nb = userManager.getAdmins().size();
+		int nb = bugTrap.getUserManager().getAdmins().size();
 		Assert.assertEquals(1, nb);
-		
-		userManager.createAdmin("", "", "", "");
-		nb = userManager.getAdmins().size();
+
+		bugTrap.getUserManager().createAdmin("", "", "", "");
+		nb = bugTrap.getUserManager().getAdmins().size();
 		Assert.assertEquals(2, nb);
 	}
 	
 	@Test
 	public void getIssuersTest() {
-		int nb = userManager.getIssuers().size();
-		Assert.assertEquals(2, nb); //issuer and dev
-		
-		userManager.createIssuer("", "", "", "");
-		nb = userManager.getIssuers().size();
-		Assert.assertEquals(3, nb);
+		int nb = bugTrap.getUserManager().getIssuers().size();
+		Assert.assertEquals(4, nb); //lead, programmer, tester and issuer
+
+		bugTrap.getUserManager().createIssuer("", "", "", "");
+		nb = bugTrap.getUserManager().getIssuers().size();
+		Assert.assertEquals(5, nb);
 	}
 	
 	@Test
 	public void getDeveloperTest() {
-		int nb = userManager.getDevelopers().size();
-		Assert.assertEquals(1, nb);
-		
-		userManager.createDeveloper("", "", "", "");
-		nb = userManager.getDevelopers().size();
-		Assert.assertEquals(2, nb);
+		int nb = bugTrap.getUserManager().getDevelopers().size();
+		Assert.assertEquals(3, nb);
+
+		bugTrap.getUserManager().createDeveloper("", "", "", "");
+		nb = bugTrap.getUserManager().getDevelopers().size();
+		Assert.assertEquals(4, nb);
 	}
 	
 	@Test
 	public void getUserSuccesTest() {
-		IUser user = userManager.getUser("RRR");
+		IUser user = bugTrap.getUserManager().getUser("ADMIN");
 		Assert.assertEquals(admin, user);
-		user = userManager.getUser("LLL");
+		user = bugTrap.getUserManager().getUser("ISSUER");
 		Assert.assertEquals(issuer, user);
-		user = userManager.getUser("CCC");
-		Assert.assertEquals(dev, user);
+		user = bugTrap.getUserManager().getUser("PROGRAMMER");
+		Assert.assertEquals(prog, user);
 	}
 	
 	@Test (expected = NoUserWithUserNameException.class)
 	public void getUserFailTest() {
-		userManager.getUser("NotAUser");
+		bugTrap.getUserManager().getUser("NotAUser");
 	}
 
 }

--- a/src/tests/usertests/UsersTests.java
+++ b/src/tests/usertests/UsersTests.java
@@ -7,45 +7,47 @@ import org.junit.Test;
 import model.users.Administrator;
 import model.users.Developer;
 import model.users.Issuer;
+import tests.BugTrapTest;
 
-public class UsersTests {
-	
-	private Administrator admin;
-	private Issuer issuer;
-	private Developer dev;
-
-	@Before
-	public void setUp() throws Exception {
-		admin = new Administrator("Richard", "Rosie", "Reese", "RRR");
-		issuer = new Issuer("Lindsey", "Lida", "Linkovic", "LLL");
-		dev = new Developer("Carl", "Casey", "Carver", "CCC");
-	}
+public class UsersTests extends BugTrapTest {
 
 	@Test
-	public void adminCreateTest() {
+	public void adminTest() {
 		Assert.assertTrue(admin.isAdmin());
-		Assert.assertEquals(admin.getFirstName(), "Richard");
-		Assert.assertEquals(admin.getMiddleName(), "Rosie");
-		Assert.assertEquals(admin.getLastName(), "Reese");
-		Assert.assertEquals(admin.getUserName(), "RRR");
+		Assert.assertEquals(admin.getFirstName(), "Bill");
+		Assert.assertEquals(admin.getMiddleName(), "");
+		Assert.assertEquals(admin.getLastName(), "Gates");
+		Assert.assertEquals(admin.getUserName(), "ADMIN");
 	}
 	
 	@Test
-	public void issuerCreateTest() {
+	public void issuerTest() {
 		Assert.assertTrue(issuer.isIssuer());
-		Assert.assertEquals(issuer.getFirstName(), "Lindsey");
-		Assert.assertEquals(issuer.getMiddleName(), "Lida");
-		Assert.assertEquals(issuer.getLastName(), "Linkovic");
-		Assert.assertEquals(issuer.getUserName(), "LLL");
+		Assert.assertEquals(issuer.getFirstName(), "Geen");
+		Assert.assertEquals(issuer.getMiddleName(), "");
+		Assert.assertEquals(issuer.getLastName(), "Idee");
+		Assert.assertEquals(issuer.getUserName(), "ISSUER");
 	}
 	
 	@Test
-	public void devCreateTest() {
-		Assert.assertTrue(dev.isDeveloper());
-		Assert.assertEquals(dev.getFirstName(), "Carl");
-		Assert.assertEquals(dev.getMiddleName(), "Casey");
-		Assert.assertEquals(dev.getLastName(), "Carver");
-		Assert.assertEquals(dev.getUserName(), "CCC");
+	public void devTest() {
+		Assert.assertTrue(lead.isDeveloper());
+		Assert.assertEquals(lead.getFirstName(), "Barack");
+		Assert.assertEquals(lead.getMiddleName(), "");
+		Assert.assertEquals(lead.getLastName(), "Obama");
+		Assert.assertEquals(lead.getUserName(), "LEAD");
+
+		Assert.assertTrue(prog.isDeveloper());
+		Assert.assertEquals(prog.getFirstName(), "Edsger");
+		Assert.assertEquals(prog.getMiddleName(), "W.");
+		Assert.assertEquals(prog.getLastName(), "Dijkstra");
+		Assert.assertEquals(prog.getUserName(), "PROGRAMMER");
+
+		Assert.assertTrue(tester.isDeveloper());
+		Assert.assertEquals(tester.getFirstName(), "Edsger");
+		Assert.assertEquals(tester.getMiddleName(), "W.");
+		Assert.assertEquals(tester.getLastName(), "Dijkstra");
+		Assert.assertEquals(tester.getUserName(), "TESTER");
 	}
 
 }


### PR DESCRIPTION
…on en ProjectTeam omdat deze klasses apart van BugTrap bestaan of afgeschermd zijn ervan). Testsuite uitgebreid voor bug tags, alle mogelijke overgangen worden nu getest. Sommige bugs gefixt. Create Bugreport gaat nu steeds via dezelfde methode, ipv 2 methodes (een voor een bugreport met target milestone en één voor bugreport zonder target milestone). Geen idee waarom dat gesplitst was...